### PR TITLE
Update for change for embed iframe link from quizlet

### DIFF
--- a/public/tools/quizlet/quizlet.js
+++ b/public/tools/quizlet/quizlet.js
@@ -8,7 +8,7 @@
   var $add = $("#add");
   function updatePreview() {
     var id = $quizlet_preview.attr('data-id');
-    url = "http://quizlet.com/" + id + "/" + $quizlet_type.val() + "/embed/?hideLinks";
+    url = "http://quizlet.com/" + id + "/" + $quizlet_type.val() + "/embedv2/";
     $quizlet.attr('rel', url);
     $quizlet_preview.attr('src', url);
     $results.hide();


### PR DESCRIPTION
Quizlet may have changed their iframe embed link as this is an example embed link from their site.

<iframe src="http://quizlet.com/1518465/familiarize/embedv2/" height="410" width="100%" style="border:0;"></iframe>

Propose change here to fix iframe link in Canvas.
