### PR TITLE
fix broken link to extensions page

### DIFF
--- a/public/code.html
+++ b/public/code.html
@@ -167,7 +167,7 @@
           </span class='label label-warning'>consumer</span>, or adding buttons to the 
           rich editor in the <span class='label label-warning'>consumer</span> to insert
           rich content generated or curated by the <span class='label label-info'>provider</span>.
-          <a href="/extensions">Check out the extensions demos page</a> or the 
+          <a href="/extensions/">Check out the extensions demos page</a> or the 
           <a href="https://canvas.instructure.com/doc/api/tools_intro.html">Canvas API documentation on external tools</a>
           for more detail on these extensions and how they work.
         </span>


### PR DESCRIPTION
a trailing slash is required, it seems
